### PR TITLE
@W-14772782@ Add Salesforce SSO login to the MetaDeploy Django's admin area

### DIFF
--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -1,0 +1,27 @@
+{% extends "admin/login.html" %}
+
+{% load socialaccount %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <style>
+        #content-main {
+            float: none !important;
+        }
+
+        .social_login_container {
+            margin-top: 15px;
+            display: flex;
+            justify-content: center;
+        }
+    </style>
+{% endblock %}
+
+{% block content %}
+    {{ block.super }}
+
+    <div class="social_login_container">
+        <a href="{% provider_login_url "salesforce" action="reauthenticate" custom_domain="login" %}">Log in with Salesforce</a>
+    </div>
+
+{% endblock %}

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -9,31 +9,23 @@
             float: none !important;
         }
 
-        @media (max-width: 767px) {
-            .salesforce-login-container {
-                margin-top: -30px;
-            }
-        }
-
         .salesforce-login-container {
             text-align: center;
-            margin-top: -80px;
-        }
-
-        #salesforce-login-form {
-            margin: 10px;
+            margin-top: 20px;
+            line-height: 2;
         }
     </style>
 {% endblock %}
 
 {% block content %}
     {{ block.super }}
-{% endblock %}
 
-<div class="salesforce-login-container">
-    <span>Or</span>
-    <form id="salesforce-login-form" method="post" action="{% provider_login_url "salesforce" %}">
-      {% csrf_token %}
-      <input type="submit" value="Log in with Salesforce" />
-    </form>
-</div>
+    <div class="salesforce-login-container">
+        <hr/>
+        <span>Or</span>
+        <form id="salesforce-login-form" method="post" action="{% provider_login_url "salesforce" %}">
+          {% csrf_token %}
+          <input type="submit" value="Log in with Salesforce" />
+        </form>
+    </div>
+{% endblock %}

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -24,13 +24,9 @@
         <a href="{% provider_login_url "salesforce" %}">Log in with Salesforce</a>
     </div>
 
-    {% element form method="post" no_visible_fields=True action="{% provider_login_url "salesforce" %}" %}
-        {% slot actions %}
-            {% csrf_token %}
-            {% element button type="submit" %}
-                {% trans "Log in with Salesforce" %}
-            {% endelement %}
-        {% endslot %}
-    {% endelement %}
+    <form method="post" action="{% provider_login_url "salesforce" %}">
+      {% csrf_token %}
+      <button type="submit">Log in with Salesforce</button>
+    </form>
 
 {% endblock %}

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -21,7 +21,7 @@
     {{ block.super }}
 
     <div class="social_login_container">
-        <a href="{% provider_login_url "salesforce" action="reauthenticate" custom_domain="login" %}">Log in with Salesforce</a>
+        <a href="{% provider_login_url "salesforce" %}">Log in with Salesforce</a>
     </div>
 
 {% endblock %}

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -9,24 +9,31 @@
             float: none !important;
         }
 
-        .social_login_container {
-            margin-top: 15px;
-            display: flex;
-            justify-content: center;
+        @media (max-width: 767px) {
+            .salesforce-login-container {
+                margin-top: -30px;
+            }
+        }
+
+        .salesforce-login-container {
+            text-align: center;
+            margin-top: -80px;
+        }
+
+        #salesforce-login-form {
+            margin: 10px;
         }
     </style>
 {% endblock %}
 
 {% block content %}
     {{ block.super }}
-
-    <div class="social_login_container">
-        <a href="{% provider_login_url "salesforce" %}">Log in with Salesforce</a>
-    </div>
-
-    <form method="post" action="{% provider_login_url "salesforce" %}">
-      {% csrf_token %}
-      <button type="submit">Log in with Salesforce</button>
-    </form>
-
 {% endblock %}
+
+<div class="salesforce-login-container">
+    <span>Or</span>
+    <form id="salesforce-login-form" method="post" action="{% provider_login_url "salesforce" %}">
+      {% csrf_token %}
+      <input type="submit" value="Log in with Salesforce" />
+    </form>
+</div>

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -24,4 +24,13 @@
         <a href="{% provider_login_url "salesforce" %}">Log in with Salesforce</a>
     </div>
 
+    {% element form method="post" no_visible_fields=True action="{% provider_login_url "salesforce" %}" %}
+        {% slot actions %}
+            {% csrf_token %}
+            {% element button type="submit" %}
+                {% trans "Log in with Salesforce" %}
+            {% endelement %}
+        {% endslot %}
+    {% endelement %}
+
 {% endblock %}


### PR DESCRIPTION
Work item: [W-14772782: Okta migration / Spike: use django-allauth with a test Metadeploy instance](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001hhmvfYAA/view)

This PR is a POC of how we could integrate Okta SSO to the MetaDeploy admin area authentication.

It consists of using the already available django-allatuh  "salesforce" provider, which is only used in the customer-facing area so far. The work flow would be:
1. Open the `/metadeploy_django_admin` URL
2. Click on the "Log in with Salesforce" button to be redirected to https://login.salesforce.com
3. Choose the "backtowork" custom domain
4. Authenticate through Okta SSO

A user would be automatically created with username like `00Daaaaaaaaaa_005bbbbbbbbbb` where "00Daaaaaaaaaa" is the authenticating org (ie. Backtowork Dev Hub) and "005bbbbbbbbbb" the user id within the org.

Then we would grant this user the "Superuser" status in Django using the backup username/password superuser account. The backup username/password superuser account would be used only for this initial step and only as a backup. Otherwise the Salesforce+Okta authentication workflow should be used.

A sample dev instance is available here: https://workplace-metadeploy-dev-ae7ad529b0b7.herokuapp.com/metadeploy_django_admin/